### PR TITLE
Change periods of the day replacements to be case-sensitive

### DIFF
--- a/lunes.go
+++ b/lunes.go
@@ -80,6 +80,11 @@ var dayPeriodsStd = []string{
 	"PM",
 }
 
+var dayPeriodsStdLower = []string{
+	"am",
+	"pm",
+}
+
 // Parse parses a formatted string in foreign language and returns the [time.Time] value
 // it represents. See the documentation for the constant called [time.Layout] to see how to
 // represent the format.
@@ -239,13 +244,23 @@ func TranslateWithLocale(layout string, value string, locale Locale) (string, er
 			}
 		case 'P', 'p': // PM, pm
 			if len(layout) >= layoutOffset+2 && unicode.ToUpper(rune(layout[layoutOffset+1])) == 'M' {
+				var layoutElem string
+				// day-periods case matters for the time package parsing functions
+				if c == 'p' {
+					layoutElem = "pm"
+					stdTab = dayPeriodsStdLower
+				} else {
+					layoutElem = "PM"
+					stdTab = dayPeriodsStd
+				}
+
 				lookupTab = locale.DayPeriods()
 				if len(lookupTab) == 0 {
-					return "", newUnsupportedLayoutElemError("PM", locale)
+					return "", newUnsupportedLayoutElemError(layoutElem, locale)
 				}
 
 				layoutOffset += 2
-				valueOffset, err = writeLayoutValue("PM", lookupTab, dayPeriodsStd, valueOffset, value, &sb)
+				valueOffset, err = writeLayoutValue(layoutElem, lookupTab, stdTab, valueOffset, value, &sb)
 				if err != nil {
 					return "", err
 				}

--- a/lunes.go
+++ b/lunes.go
@@ -75,7 +75,7 @@ var longMonthNamesStd = []string{
 	"December",
 }
 
-var dayPeriodsStd = []string{
+var dayPeriodsStdUpper = []string{
 	"AM",
 	"PM",
 }
@@ -251,7 +251,7 @@ func TranslateWithLocale(layout string, value string, locale Locale) (string, er
 					stdTab = dayPeriodsStdLower
 				} else {
 					layoutElem = "PM"
-					stdTab = dayPeriodsStd
+					stdTab = dayPeriodsStdUpper
 				}
 
 				lookupTab = locale.DayPeriods()

--- a/lunes_test.go
+++ b/lunes_test.go
@@ -818,6 +818,56 @@ func TestParsingWithUnsupportedLocale(t *testing.T) {
 	})
 }
 
+func TestDayPeriodsLayoutCase(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		value  string
+		lang   string
+	}{
+		{
+			name:   "AllLowerPm",
+			format: "Monday January 03:04:05pm",
+			value:  "lunes enero 03:04:05a.m.",
+			lang:   LocaleEs,
+		},
+		{
+			name:   "AllUpperPm",
+			format: "Monday January 03:04:05PM",
+			value:  "Monday January 03:04:05AM",
+			lang:   LocaleEnUS,
+		},
+		{
+			name:   "UpperPmLowerValue",
+			format: "Monday January 03:04:05PM",
+			value:  "Monday January 03:04:05am",
+			lang:   LocaleEnUS,
+		},
+		{
+			name:   "LowerPmUpperValue",
+			format: "Monday January 03:04:05pm",
+			value:  "Monday January 03:04:05AM",
+			lang:   LocaleEnUS,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("ParseWith%s", test.name), func(t *testing.T) {
+			_, err := Parse(test.format, test.value, test.lang)
+			if err != nil {
+				t.Errorf("no error expected, got: '%v'", err)
+			}
+		})
+
+		t.Run(fmt.Sprintf("ParseInLocationWith%s", test.name), func(t *testing.T) {
+			_, err := ParseInLocation(test.format, test.value, test.lang, defaultLocation)
+			if err != nil {
+				t.Errorf("no error expected, got: '%v'", err)
+			}
+		})
+	}
+}
+
 func TestAllLocalesReplacements(t *testing.T) {
 	var shortLayoutTests []ParseTest
 	var longLayoutTests []ParseTest

--- a/lunes_test.go
+++ b/lunes_test.go
@@ -876,7 +876,7 @@ func TestAllLocalesReplacements(t *testing.T) {
 		day := month % 7
 		period := month % 2
 
-		shortStdValue := fmt.Sprintf("%s %s 03:04:05%s", shortDayNamesStd[day], shortMonthNamesStd[month], dayPeriodsStd[period])
+		shortStdValue := fmt.Sprintf("%s %s 03:04:05%s", shortDayNamesStd[day], shortMonthNamesStd[month], dayPeriodsStdUpper[period])
 		shortLayoutTests = append(shortLayoutTests, ParseTest{
 			name:     shortStdValue,
 			format:   "Mon Jan 03:04:05PM",
@@ -886,7 +886,7 @@ func TestAllLocalesReplacements(t *testing.T) {
 			locales:  allLocalesTests("%s %s 03:04:05%s", []replacement{{shortDayNamesField, day}, {shortMonthNamesField, month}, {dayPeriodsField, period}}),
 		})
 
-		longStdValue := fmt.Sprintf("%s %s 03:04:05%s", longDayNamesStd[day], longMonthNamesStd[month], dayPeriodsStd[period])
+		longStdValue := fmt.Sprintf("%s %s 03:04:05%s", longDayNamesStd[day], longMonthNamesStd[month], dayPeriodsStdUpper[period])
 		longLayoutTests = append(longLayoutTests, ParseTest{
 			format:   "Monday January 03:04:05PM",
 			stdValue: longStdValue,

--- a/tables_test.go
+++ b/tables_test.go
@@ -32,7 +32,7 @@ func TestLocaleTableEn(t *testing.T) {
 		longDayNamesStd,
 		shortMonthNamesStd,
 		longMonthNamesStd,
-		dayPeriodsStd,
+		dayPeriodsStdUpper,
 	}
 
 	lang := "en"


### PR DESCRIPTION
The Go time parsing requires the period of the day value and the layout element to be in the same letter case.
For example, If `pm` in lower case is used as template, it expects the value to be also in lower case (`am`, `pm`), otherwise an error will be returned by the `time.Parse` functions.

This PR changes lunes to replace the day periods elements respecting the define layout case, for example:

layout: `January 02 Monday, 2006, 03:04:05 pm`
value: `Febrero 25 jueves, 1993, 02:03:04 a.m.`
lang: `es-ES`

Before this change, it would translate the value to `February 25 Thursday, 1993, 02:03:04 AM` (upper case AM), which would fail to parse using the time.Parse:

 ```go
val, _ := lunes.Translate("January 02 Monday, 2006, 03:04:05 pm", "Febrero 25 jueves, 1993, 02:03:04 a.m.", "es-ES")

// it returns an error, as the "AM" value cannot be parsed as a "pm" layout element. 
time.Parse("January 02 Monday, 2006, 03:04:05 pm", val)
```

With this PR changes, the case is maintained, and the same `Translate` function call will return `February 25 Thursday, 1993, 02:03:04 am` (lower case am), making the `time.Parse` function work as exptected.

--

Note: The locale translations lookup for periods of the day are still being compared using case-insensitive, it didn't change. the only thing that was changed is the layout element replacement (`AM`, `PM`), that are now replaced using the same layout letter case.